### PR TITLE
fix(draw): handle non-string symbols in get_screen

### DIFF
--- a/ssrpgif/core.py
+++ b/ssrpgif/core.py
@@ -166,7 +166,10 @@ class SSRPGInterface:
         """Retrieves a portion of the game screen as text."""
         requests = [["draw.GetSymbol", x + col, y + row] for row in range(h) for col in range(w)]
         raw_symbols = self.multi_call(requests)
-        return '\n'.join(''.join(raw_symbols[i:i+w]) for i in range(0, len(raw_symbols), w))
+        
+        # Ensure all symbols are strings before joining
+        str_symbols = [str(symbol) for symbol in raw_symbols]
+        return '\n'.join(''.join(str_symbols[i:i+w]) for i in range(0, len(str_symbols), w))
 
 class _MindConnectClient:
     # Internal class handling low-level protocol details.


### PR DESCRIPTION
The draw.GetSymbol API may return integers (e.g., digits) alongside strings.
Calling ''.join() on a list containing integers raises a TypeError.
Convert all symbols to strings before joining to ensure compatibility.